### PR TITLE
Derive Clone/Debug on Proof

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,7 @@ impl From<Scalar> for ed25519::Scalar {
 
 /// Non-interactive zero-knowledge proof of knowledge of the same discrete
 /// logarithm across secp256k1 and ed25519.
+#[derive(Clone, Debug)]
 pub struct Proof {
     /// Pedersen Commitments for bits of the secp256k1 scalar.
     ///


### PR DESCRIPTION
In order to be able to clone messages we need `Proof` to be clonable. And in
order to use it with other projects we have that enforce the need to have
`Debug` implemented its helpful to derive that also.