### PR TITLE
Replace generic array with vec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ generic-array = "0.14"
 hex-literal = "0.2"
 lazy_static = "1.4"
 rand = "0.7"
-serde_crate = { package = "serde", version = "1.0", optional = true, default-features = false, features = ["derive"] }
+serde_crate = { package = "serde", version = "1.0", optional = true, default-features = false, features = ["derive", "alloc"] }
 sha2 = "0.9"
 thiserror = "1"
 
@@ -20,4 +20,4 @@ thiserror = "1"
 proptest = "0.10"
 
 [features]
-serde = ["serde_crate", "ecdsa_fun/serialization", "curve25519-dalek/serde", "generic-array/serde"]
+serde = ["serde_crate", "ecdsa_fun/serialization", "curve25519-dalek/serde"]


### PR DESCRIPTION
This speeds up the painfully slow compilation of the swap crate in
xmr-btc-swap.

Attempt to fix https://github.com/comit-network/xmr-btc-swap/issues/31